### PR TITLE
Feat/ 사용자 프로필 API 구현

### DIFF
--- a/src/main/java/caps/ssl/chat/model/ChatMessage.java
+++ b/src/main/java/caps/ssl/chat/model/ChatMessage.java
@@ -2,7 +2,6 @@ package caps.ssl.chat.model;
 
 import caps.ssl.contract.model.Contract;
 import caps.ssl.member.model.Member;
-import caps.ssl.checklist.model.SenderType;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/caps/ssl/chat/model/SenderType.java
+++ b/src/main/java/caps/ssl/chat/model/SenderType.java
@@ -1,4 +1,4 @@
-package caps.ssl.checklist.model;
+package caps.ssl.chat.model;
 
 public enum SenderType {
     USER, // 사용자

--- a/src/main/java/caps/ssl/member/controller/Ex.java
+++ b/src/main/java/caps/ssl/member/controller/Ex.java
@@ -1,4 +1,0 @@
-package caps.ssl.member.controller;
-
-public class Ex {
-}

--- a/src/main/java/caps/ssl/member/controller/MemberController.java
+++ b/src/main/java/caps/ssl/member/controller/MemberController.java
@@ -9,29 +9,29 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/members") // 공통된 URL 경로 설정
+@RequestMapping("/api/members")
 public class MemberController {
 
     private final MemberService memberService;
 
-    // 사용자 상세 조회 (GET /api/members/{id})
+
     @GetMapping("/{id}")
     public ResponseEntity<MemberResDto> getMemberProfile(@PathVariable("id") Long memberId) {
         MemberResDto responseDto = memberService.getMemberProfile(memberId);
         return ResponseEntity.ok(responseDto);
     }
 
-    // 사용자 정보 수정 (PUT /api/members/{id})
+
     @PutMapping("/{id}")
     public ResponseEntity<Long> updateMemberProfile(@PathVariable("id") Long memberId, @RequestBody MemberUpdateDto requestDto) {
         Long updatedMemberId = memberService.updateMemberProfile(memberId, requestDto);
         return ResponseEntity.ok(updatedMemberId);
     }
 
-    // 사용자 삭제 (DELETE /api/members/{id})
+
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteMember(@PathVariable("id") Long memberId) {
         memberService.deleteMember(memberId);
-        return ResponseEntity.noContent().build(); // 내용 없이 성공적인 응답 (204 No Content)
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/caps/ssl/member/controller/MemberController.java
+++ b/src/main/java/caps/ssl/member/controller/MemberController.java
@@ -1,0 +1,37 @@
+package caps.ssl.member.controller;
+
+import caps.ssl.member.dto.MemberResDto;
+import caps.ssl.member.dto.MemberUpdateDto;
+import caps.ssl.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members") // 공통된 URL 경로 설정
+public class MemberController {
+
+    private final MemberService memberService;
+
+    // 사용자 상세 조회 (GET /api/members/{id})
+    @GetMapping("/{id}")
+    public ResponseEntity<MemberResDto> getMemberProfile(@PathVariable("id") Long memberId) {
+        MemberResDto responseDto = memberService.getMemberProfile(memberId);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 사용자 정보 수정 (PUT /api/members/{id})
+    @PutMapping("/{id}")
+    public ResponseEntity<Long> updateMemberProfile(@PathVariable("id") Long memberId, @RequestBody MemberUpdateDto requestDto) {
+        Long updatedMemberId = memberService.updateMemberProfile(memberId, requestDto);
+        return ResponseEntity.ok(updatedMemberId);
+    }
+
+    // 사용자 삭제 (DELETE /api/members/{id})
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteMember(@PathVariable("id") Long memberId) {
+        memberService.deleteMember(memberId);
+        return ResponseEntity.noContent().build(); // 내용 없이 성공적인 응답 (204 No Content)
+    }
+}

--- a/src/main/java/caps/ssl/member/controller/MemberController.java
+++ b/src/main/java/caps/ssl/member/controller/MemberController.java
@@ -1,11 +1,14 @@
 package caps.ssl.member.controller;
 
 import caps.ssl.member.dto.MemberResDto;
-import caps.ssl.member.dto.MemberUpdateDto;
+import caps.ssl.member.dto.MemberSignupReqDto;
+import caps.ssl.member.dto.MemberUpdateReqDto;
 import caps.ssl.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,7 +17,15 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    // 사용자 추가
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signup(@RequestBody MemberSignupReqDto requestDto) {
+        Long memberId = memberService.signup(requestDto);
+        return ResponseEntity.created(URI.create("/api/members/" + memberId)).build();
+    }
 
+
+    // 사용자 정보 조회
     @GetMapping("/{id}")
     public ResponseEntity<MemberResDto> getMemberProfile(@PathVariable("id") Long memberId) {
         MemberResDto responseDto = memberService.getMemberProfile(memberId);
@@ -22,13 +33,15 @@ public class MemberController {
     }
 
 
+    // 사용자 정보 수정
     @PutMapping("/{id}")
-    public ResponseEntity<Long> updateMemberProfile(@PathVariable("id") Long memberId, @RequestBody MemberUpdateDto requestDto) {
+    public ResponseEntity<Long> updateMemberProfile(@PathVariable("id") Long memberId, @RequestBody MemberUpdateReqDto requestDto) {
         Long updatedMemberId = memberService.updateMemberProfile(memberId, requestDto);
         return ResponseEntity.ok(updatedMemberId);
     }
 
 
+    // 사용자 정보 삭제
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteMember(@PathVariable("id") Long memberId) {
         memberService.deleteMember(memberId);

--- a/src/main/java/caps/ssl/member/dto/Ex.java
+++ b/src/main/java/caps/ssl/member/dto/Ex.java
@@ -1,4 +1,0 @@
-package caps.ssl.member.dto;
-
-public class Ex {
-}

--- a/src/main/java/caps/ssl/member/dto/MemberResDto.java
+++ b/src/main/java/caps/ssl/member/dto/MemberResDto.java
@@ -1,0 +1,20 @@
+package caps.ssl.member.dto;
+
+
+import caps.ssl.member.model.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberResDto {
+    private Long memberId;
+    private String nickname;
+    private String phoneNumber;
+
+    public MemberResDto(Member member) {
+        this.memberId = member.getId();
+        this.nickname = member.getNickname();
+        this.phoneNumber = member.getPhoneNumber();
+    }
+}

--- a/src/main/java/caps/ssl/member/dto/MemberSignupReqDto.java
+++ b/src/main/java/caps/ssl/member/dto/MemberSignupReqDto.java
@@ -1,0 +1,14 @@
+package caps.ssl.member.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberSignupReqDto {
+
+    private String nickname;
+    private String password;
+    private String phoneNumber;
+
+}

--- a/src/main/java/caps/ssl/member/dto/MemberUpdateDto.java
+++ b/src/main/java/caps/ssl/member/dto/MemberUpdateDto.java
@@ -1,0 +1,12 @@
+package caps.ssl.member.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberUpdateDto {
+    private String nickname;
+    private String password;
+}

--- a/src/main/java/caps/ssl/member/dto/MemberUpdateReqDto.java
+++ b/src/main/java/caps/ssl/member/dto/MemberUpdateReqDto.java
@@ -6,7 +6,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class MemberUpdateDto {
+public class MemberUpdateReqDto {
     private String nickname;
     private String password;
 }

--- a/src/main/java/caps/ssl/member/model/Member.java
+++ b/src/main/java/caps/ssl/member/model/Member.java
@@ -1,6 +1,7 @@
 package caps.ssl.member.model;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -29,5 +30,12 @@ public class Member {
         if (password != null) {
             this.password = password;
         }
+    }
+
+    @Builder
+    public Member(String nickname, String password, String phoneNumber) {
+        this.nickname = nickname;
+        this.password = password;
+        this.phoneNumber = phoneNumber;
     }
 }

--- a/src/main/java/caps/ssl/member/model/Member.java
+++ b/src/main/java/caps/ssl/member/model/Member.java
@@ -21,4 +21,13 @@ public class Member {
 
     @Column(unique = true)
     private String phoneNumber;
+
+    public void update(String nickname, String password) {
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        if (password != null) {
+            this.password = password;
+        }
+    }
 }

--- a/src/main/java/caps/ssl/member/repository/Ex.java
+++ b/src/main/java/caps/ssl/member/repository/Ex.java
@@ -1,4 +1,0 @@
-package caps.ssl.member.repository;
-
-public class Ex {
-}

--- a/src/main/java/caps/ssl/member/repository/MemberRepository.java
+++ b/src/main/java/caps/ssl/member/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package caps.ssl.member.repository;
+
+import caps.ssl.member.model.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/java/caps/ssl/member/repository/MemberRepository.java
+++ b/src/main/java/caps/ssl/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/caps/ssl/member/service/Ex.java
+++ b/src/main/java/caps/ssl/member/service/Ex.java
@@ -1,4 +1,0 @@
-package caps.ssl.member.service;
-
-public class Ex {
-}

--- a/src/main/java/caps/ssl/member/service/MemberService.java
+++ b/src/main/java/caps/ssl/member/service/MemberService.java
@@ -1,0 +1,42 @@
+package caps.ssl.member.service;
+
+import caps.ssl.member.dto.MemberResDto;
+import caps.ssl.member.dto.MemberUpdateDto;
+import caps.ssl.member.model.Member;
+import caps.ssl.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    // 사용자 상세 조회
+    @Transactional(readOnly = true)
+    public MemberResDto getMemberProfile(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. id=" + memberId));
+
+        return new MemberResDto(member);
+    }
+
+    // 사용자 정보 수정
+    @Transactional // 데이터 변경이 있으므로 readOnly=false (기본값)
+    public Long updateMemberProfile(Long memberId, MemberUpdateDto requestDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. id=" + memberId));
+
+        member.update(requestDto.getNickname(), requestDto.getPassword());
+        return memberId;
+    }
+
+    // 사용자 삭제
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. id=" + memberId));
+        memberRepository.delete(member);
+    }
+}

--- a/src/main/java/caps/ssl/member/service/MemberService.java
+++ b/src/main/java/caps/ssl/member/service/MemberService.java
@@ -23,7 +23,7 @@ public class MemberService {
     }
 
     // 사용자 정보 수정
-    @Transactional // 데이터 변경이 있으므로 readOnly=false (기본값)
+    @Transactional
     public Long updateMemberProfile(Long memberId, MemberUpdateDto requestDto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. id=" + memberId));

--- a/src/main/java/caps/ssl/member/service/MemberService.java
+++ b/src/main/java/caps/ssl/member/service/MemberService.java
@@ -1,7 +1,8 @@
 package caps.ssl.member.service;
 
 import caps.ssl.member.dto.MemberResDto;
-import caps.ssl.member.dto.MemberUpdateDto;
+import caps.ssl.member.dto.MemberSignupReqDto;
+import caps.ssl.member.dto.MemberUpdateReqDto;
 import caps.ssl.member.model.Member;
 import caps.ssl.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,23 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+
+    @Transactional
+    public Long signup(MemberSignupReqDto requestDto) {
+        if (memberRepository.existsByNickname(requestDto.getNickname())) {
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }
+
+        Member member = Member.builder()
+                .nickname(requestDto.getNickname())
+                .password(requestDto.getPassword())
+                .phoneNumber(requestDto.getPhoneNumber())
+                .build();
+
+        Member savedMember = memberRepository.save(member);
+        return savedMember.getId();
+    }
+
 
     // 사용자 상세 조회
     @Transactional(readOnly = true)
@@ -24,7 +42,7 @@ public class MemberService {
 
     // 사용자 정보 수정
     @Transactional
-    public Long updateMemberProfile(Long memberId, MemberUpdateDto requestDto) {
+    public Long updateMemberProfile(Long memberId, MemberUpdateReqDto requestDto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 사용자를 찾을 수 없습니다. id=" + memberId));
 


### PR DESCRIPTION
### 주요 구현 사항
- **사용자(Member) API**
  - `POST /api/members/signup`: 회원가입 기능
  - `GET /api/members/{id}`: 사용자 정보 조회 기능
  - `PUT /api/members/{id}`: 사용자 정보 수정 기능
  - `DELETE /api/members/{id}`: 사용자 삭제(탈퇴) 기능

- checklist/model 안에 있던 SenderType -> chat/model 위치로 이동